### PR TITLE
Fix quotes bug

### DIFF
--- a/src/Aws/Lambda/Runtime/ApiGatewayInfo.hs
+++ b/src/Aws/Lambda/Runtime/ApiGatewayInfo.hs
@@ -1,23 +1,30 @@
-{-# LANGUAGE DuplicateRecordFields #-}
+{-# LANGUAGE DefaultSignatures          #-}
+{-# LANGUAGE DerivingStrategies         #-}
+{-# LANGUAGE DuplicateRecordFields      #-}
+{-# LANGUAGE FlexibleInstances          #-}
+{-# LANGUAGE GeneralisedNewtypeDeriving #-}
+{-# LANGUAGE UndecidableInstances       #-}
 
 module Aws.Lambda.Runtime.ApiGatewayInfo
   ( ApiGatewayRequest(..)
   , ApiGatewayRequestContext(..)
   , ApiGatewayRequestContextIdentity(..)
   , ApiGatewayResponse(..)
+  , ApiGatewayResponseBody(..)
+  , ToApiGatewayResponseBody(..)
   , mkApiGatewayResponse ) where
 
 import Data.Aeson
+import Data.Aeson.Types (Parser)
+import qualified Data.Aeson.Types as T
+import qualified Data.ByteString.Lazy.Char8 as LazyByteString
+import qualified Data.CaseInsensitive as CI
 import Data.HashMap.Strict (HashMap)
 import Data.Text (Text)
 import qualified Data.Text as T
 import qualified Data.Text.Encoding as T
 import GHC.Generics (Generic)
 import Network.HTTP.Types
-import qualified Data.CaseInsensitive as CI
-import qualified Data.Aeson.Types as T
-import qualified Data.ByteString.Lazy.Char8 as LazyByteString
-import Data.Aeson.Types (Parser)
 
 data ApiGatewayRequest body = ApiGatewayRequest
   { apiGatewayRequestResource              :: !Text
@@ -32,19 +39,42 @@ data ApiGatewayRequest body = ApiGatewayRequest
   , apiGatewayRequestBody                  :: !(Maybe body)
   } deriving (Show)
 
+-- We special case String and Text in order
+-- to avoid unneeded encoding which will wrap them in quotes and break parsing
+instance {-# OVERLAPPING #-} FromJSON (ApiGatewayRequest Text) where
+  parseJSON = parseApiGatewayRequest (.:)
+
+instance {-# OVERLAPPING #-} FromJSON (ApiGatewayRequest String) where
+  parseJSON = parseApiGatewayRequest (.:)
+
 instance FromJSON body => FromJSON (ApiGatewayRequest body) where
-  parseJSON (Object v) = ApiGatewayRequest <$>
-    v .: "resource" <*>
-    v .: "path" <*>
-    v .: "httpMethod" <*>
-    v .: "headers" <*>
-    v .: "queryStringParameters" <*>
-    v .: "pathParameters" <*>
-    v .: "stageVariables" <*>
-    v .: "isBase64Encoded" <*>
-    v .: "requestContext" <*>
-    v `parseObjectFromStringField` "body"
-  parseJSON _ = fail "Expected ApiGatewayRequest to be an object."
+  parseJSON = parseApiGatewayRequest parseObjectFromStringField
+
+-- We need this because API Gateway is going to send us the payload as a JSON string
+parseObjectFromStringField :: FromJSON a => Object -> Text -> Parser (Maybe a)
+parseObjectFromStringField obj fieldName = do
+  fieldContents <- obj .: fieldName
+  case fieldContents of
+    String stringContents ->
+      case eitherDecodeStrict (T.encodeUtf8 stringContents) of
+        Right success -> pure success
+        Left err      -> fail err
+    Null -> pure Nothing
+    other -> T.typeMismatch "String or Null" other
+
+parseApiGatewayRequest :: (Object -> Text -> Parser (Maybe body)) -> Value -> Parser (ApiGatewayRequest body)
+parseApiGatewayRequest bodyParser (Object v) = ApiGatewayRequest <$>
+  v .: "resource" <*>
+  v .: "path" <*>
+  v .: "httpMethod" <*>
+  v .: "headers" <*>
+  v .: "queryStringParameters" <*>
+  v .: "pathParameters" <*>
+  v .: "stageVariables" <*>
+  v .: "isBase64Encoded" <*>
+  v .: "requestContext" <*>
+  v `bodyParser` "body"
+parseApiGatewayRequest _ _ = fail "Expected ApiGatewayRequest to be an object."
 
 data ApiGatewayRequestContext = ApiGatewayRequestContext
   { apiGatewayRequestContextResourceId        :: !Text
@@ -112,17 +142,22 @@ instance FromJSON ApiGatewayRequestContextIdentity where
     v .: "user"
   parseJSON _ = fail "Expected ApiGatewayRequestContextIdentity to be an object."
 
--- We need this because API Gateway is going to send us the payload as a JSON string
-parseObjectFromStringField :: FromJSON a => Object -> Text -> Parser (Maybe a)
-parseObjectFromStringField obj fieldName = do
-  fieldContents <- obj .: fieldName
-  case fieldContents of
-    String stringContents ->
-      case eitherDecodeStrict (T.encodeUtf8 stringContents) of
-        Right success -> pure success
-        Left err -> fail err
-    Null -> pure Nothing
-    other -> T.typeMismatch "String or Null" other
+newtype ApiGatewayResponseBody =
+  ApiGatewayResponseBody Text
+  deriving newtype (ToJSON, FromJSON)
+
+class ToApiGatewayResponseBody a where
+  toApiGatewayResponseBody :: a -> ApiGatewayResponseBody
+
+-- We special case Text and String to avoid unneeded encoding which will wrap them in quotes
+instance {-# OVERLAPPING #-} ToApiGatewayResponseBody Text where
+  toApiGatewayResponseBody = ApiGatewayResponseBody
+
+instance {-# OVERLAPPING #-} ToApiGatewayResponseBody String where
+  toApiGatewayResponseBody = ApiGatewayResponseBody . T.pack
+
+instance ToJSON a => ToApiGatewayResponseBody a where
+  toApiGatewayResponseBody = ApiGatewayResponseBody . toJSONText
 
 data ApiGatewayResponse body = ApiGatewayResponse
   { apiGatewayResponseStatusCode      :: !Int
@@ -135,12 +170,15 @@ instance Functor ApiGatewayResponse where
   fmap f v = v { apiGatewayResponseBody = f (apiGatewayResponseBody v) }
 
 instance ToJSON body => ToJSON (ApiGatewayResponse body)  where
-  toJSON ApiGatewayResponse {..} = object
-    [ "statusCode" .= apiGatewayResponseStatusCode
-    , "body" .= (String . T.pack . LazyByteString.unpack . encode @body $ apiGatewayResponseBody)
-    , "headers" .= object (map headerToPair apiGatewayResponseHeaders)
-    , "isBase64Encoded" .= apiGatewayResponseIsBase64Encoded
-    ]
+  toJSON = apiGatewayResponseToJSON toJSON
+
+apiGatewayResponseToJSON :: (body -> Value) -> ApiGatewayResponse body -> Value
+apiGatewayResponseToJSON bodyTransformer ApiGatewayResponse {..} = object
+  [ "statusCode" .= apiGatewayResponseStatusCode
+  , "body" .= bodyTransformer apiGatewayResponseBody
+  , "headers" .= object (map headerToPair apiGatewayResponseHeaders)
+  , "isBase64Encoded" .= apiGatewayResponseIsBase64Encoded
+  ]
 
 mkApiGatewayResponse :: Int -> payload -> ApiGatewayResponse payload
 mkApiGatewayResponse code payload =
@@ -151,3 +189,6 @@ headerToPair (cibyte, bstr) = k .= v
  where
   k = (T.decodeUtf8 . CI.original) cibyte
   v = T.decodeUtf8 bstr
+
+toJSONText :: ToJSON a => a -> Text
+toJSONText = T.pack . LazyByteString.unpack . encode

--- a/src/Aws/Lambda/Runtime/Common.hs
+++ b/src/Aws/Lambda/Runtime/Common.hs
@@ -12,11 +12,10 @@ module Aws.Lambda.Runtime.Common
   ) where
 
 import Aws.Lambda.Runtime.ApiGatewayInfo
-import Data.Aeson (Value)
-import GHC.Generics (Generic)
-import Language.Haskell.TH.Syntax (Lift)
 import Aws.Lambda.Runtime.Context (Context)
 import qualified Data.ByteString.Lazy as Lazy
+import GHC.Generics (Generic)
+import Language.Haskell.TH.Syntax (Lift)
 
 -- | API Gateway specific dispatcher options
 newtype ApiGatewayDispatcherOptions = ApiGatewayDispatcherOptions
@@ -46,12 +45,12 @@ type RunCallback context =
 -- | Wrapper type for lambda execution results
 data LambdaError =
   StandaloneLambdaError String |
-  ApiGatewayLambdaError (ApiGatewayResponse Value)
+  ApiGatewayLambdaError (ApiGatewayResponse ApiGatewayResponseBody)
 
 -- | Wrapper type to handle the result of the user
 data LambdaResult =
   StandaloneLambdaResult String |
-  ApiGatewayResult (ApiGatewayResponse Value)
+  ApiGatewayResult (ApiGatewayResponse ApiGatewayResponseBody)
 
 -- | Options that the generated main expects
 data LambdaOptions context = LambdaOptions

--- a/src/Aws/Lambda/Runtime/Publish.hs
+++ b/src/Aws/Lambda/Runtime/Publish.hs
@@ -25,7 +25,7 @@ result lambdaResult lambdaApi context manager = do
 
   let requestBody = case lambdaResult of
         (StandaloneLambdaResult res) -> Http.RequestBodyBS (ByteString.pack res)
-        (ApiGatewayResult res) -> Http.RequestBodyLBS (encode res)
+        (ApiGatewayResult res)       -> Http.RequestBodyLBS (encode res)
       request = rawRequest
                 { Http.method = "POST"
                 , Http.requestBody = requestBody


### PR DESCRIPTION
ApiGatewayResponse now uses a custom ApiGatewayResponseBody type to contain the responses instead of Data.Aeson.Value. This allows us to special case the Text and String cases and fix the quotes that appeared around responses.